### PR TITLE
Add docker deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+__pycache__
+*.pyc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ "master", "main" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/telegramsupportbot:latest
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/telegramsupportbot:latest
+            docker stop telegramsupportbot || true
+            docker rm telegramsupportbot || true
+            docker run -d --name telegramsupportbot --restart always \
+              -v ${{ secrets.CONFIG_PATH }}:/app/config.py \
+              ${{ secrets.DOCKERHUB_USERNAME }}/telegramsupportbot:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY telegram-bot /app
+
+CMD ["python3", "bot.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  bot:
+    build: .
+    container_name: telegramsupportbot
+    volumes:
+      - ./telegram-bot/config.py:/app/config.py
+    restart: unless-stopped
+    command: python3 bot.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyTelegramBotAPI
+cryptography
+pymysql


### PR DESCRIPTION
## Summary
- create requirements.txt for Python dependencies
- add Dockerfile and docker-compose setup for running the bot in a container
- deploy via GitHub Actions using DockerHub and SSH

## Testing
- `python3 -m py_compile telegram-bot/*.py`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0024e134832d90f581b4a8aba55b