### PR TITLE
Fix UnicodeEncodeError by decoding surrogate pairs

### DIFF
--- a/telegram-bot/locales.py
+++ b/telegram-bot/locales.py
@@ -128,4 +128,10 @@ TEXTS = {
 }
 
 def t(lang, key, **kwargs):
-    return TEXTS.get(lang, TEXTS['en']).get(key, '').format(**kwargs)
+    raw_text = TEXTS.get(lang, TEXTS['en']).get(key, '')
+    try:
+        # convert explicit surrogate pairs to real emoji characters
+        decoded_text = raw_text.encode('utf-16', 'surrogatepass').decode('utf-16')
+    except UnicodeEncodeError:
+        decoded_text = raw_text
+    return decoded_text.format(**kwargs)


### PR DESCRIPTION
## Summary
- decode surrogate pairs when retrieving localization strings to avoid Unicode errors

## Testing
- `python3 -m py_compile telegram-bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688736d00270832da1c3268fcb97429f