### PR TITLE
Fix language persistence

### DIFF
--- a/telegram-bot/core.py
+++ b/telegram-bot/core.py
@@ -25,7 +25,14 @@ def get_user_lang(user_id):
 def set_user_lang(user_id, lang):
     con = pymysql.connect(host=config.MySQL[0], user=config.MySQL[1], passwd=config.MySQL[2], db=config.MySQL[3])
     cur = con.cursor()
-    cur.execute("INSERT INTO users (user_id, lang) VALUES (%s, %s) ON DUPLICATE KEY UPDATE lang=%s", (user_id, lang, lang))
+
+    # Check if the user already exists to avoid duplications
+    cur.execute("SELECT id FROM users WHERE user_id=%s", (user_id,))
+    if cur.fetchone():
+        cur.execute("UPDATE users SET lang=%s WHERE user_id=%s", (lang, user_id))
+    else:
+        cur.execute("INSERT INTO users (user_id, lang) VALUES (%s, %s)", (user_id, lang))
+
     con.commit()
     cur.close()
     con.close()

--- a/telegram-bot/sql.py
+++ b/telegram-bot/sql.py
@@ -61,7 +61,7 @@ def create_table_users():
     con = pymysql.connect(host=config.MySQL[0], user=config.MySQL[1], passwd=config.MySQL[2], db=config.MySQL[3])
     cur = con.cursor()
 
-    cur.execute("CREATE TABLE IF NOT EXISTS users(id INT NOT NULL AUTO_INCREMENT, `user_id` VARCHAR(20), `lang` VARCHAR(5), PRIMARY KEY (id))")
+    cur.execute("CREATE TABLE IF NOT EXISTS users(id INT NOT NULL AUTO_INCREMENT, `user_id` VARCHAR(20) UNIQUE, `lang` VARCHAR(5), PRIMARY KEY (id))")
     cur.execute(f"ALTER TABLE users CONVERT TO CHARACTER SET utf8mb4")
 
     cur.close()


### PR DESCRIPTION
## Summary
- update `set_user_lang` to update existing records rather than insert duplicates
- make `user_id` unique when creating the `users` table

## Testing
- `python3 -m py_compile telegram-bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68873f96b684832da13fa8cf4c470679